### PR TITLE
Fixed PyDICOM import 

### DIFF
--- a/anonymizer_methods.py
+++ b/anonymizer_methods.py
@@ -7,7 +7,13 @@ import glob
 import platform
 import shutil
 from shutil import move
-import dicom
+try:
+    __import__('pydicom')
+    import pydicom as dicom
+except ImportError:
+    import dicom
+
+
 
 ###################################
 # Read dicom fields from XML file #


### PR DESCRIPTION
PyDICOM was imported in the past version using "import dicom" but latest version need to be imported using "import pydicom as dicom". This pull request tries to import one or the other depending on what is available in the filesystem.