### PR TITLE
Specify full path to fields_to_zap.xml

### DIFF
--- a/anonymizer_gui.py
+++ b/anonymizer_gui.py
@@ -70,7 +70,7 @@ class dicom_anonymizer(Frame):
         return self.dirname
         
     def anonymize(self):
-        XML_file = "fields_to_zap.xml"    
+        XML_file = os.path.dirname(os.path.abspath(__file__)) + "/fields_to_zap.xml"
         field_dict=methods.Grep_DICOM_fields(XML_file)
         field_dict=methods.Grep_DICOM_values(self.dirname, field_dict)
         fields_keys=list(field_dict.keys())


### PR DESCRIPTION
Specify full path to fields_to_zap.xml. This is to fix `IOError No such file or directory: 'fields_to_zap.xml'`