### PR TITLE
Parse DICOMs recursively

### DIFF
--- a/anonymizer_gui.py
+++ b/anonymizer_gui.py
@@ -46,10 +46,6 @@ class dicom_anonymizer(Frame):
         self.buttonView.grid(row=0, column=0, padx=(0,10), sticky=E+W)
         self.buttonView.configure(state=DISABLED)
 
-        self.buttonZip = Button(self.buttonsPanel, text=u"Zip DICOM folder", command=self.zipDicom)
-        self.buttonZip.grid(row=0, column=1, padx=(10,0), sticky=E+W)
-        self.buttonZip.configure(state=DISABLED)
-
         self.center(self.parent)
     
     def center(self, win):
@@ -66,7 +62,6 @@ class dicom_anonymizer(Frame):
         self.dirname=tkFileDialog.askdirectory(**self.dir_opt)
         self.entryVariable.set(self.dirname)
         self.buttonView.configure(state=NORMAL)
-        self.buttonZip.configure(state=NORMAL)
         return self.dirname
         
     def anonymize(self):
@@ -152,25 +147,12 @@ class dicom_anonymizer(Frame):
 
          (anonymize_dcm, original_dcm) = methods.Dicom_zapping(self.dirname, self.field_dict)
          self.field_edit_win.destroy()
-         if os.listdir(anonymize_dcm) != [] and os.listdir(original_dcm) != []:
+         if os.path.exists(anonymize_dcm) != [] and os.path.exists(original_dcm) != []:
              tkMessageBox.showinfo("Message", "Congrats! Your have successfully anonymized your files!")
          else:
              tkMessageBox.showinfo("Message", "There was an error when processing files")  
             
 
-    def zipDicom(self):
-         directory = self.entry.get()
-         archiveName = directory 
-         if (os.listdir(directory) == []):
-             tkMessageBox.showinfo("Message", "The directory " + directory + " is empty")
-         else:
-             self.config(cursor="watch")
-             self.update()
-             make_archive(archiveName, 'zip', directory)
-             tkMessageBox.showinfo("Message", "A new file " + archiveName + ".zip has been created")
-             self.config(cursor="arrow")
-             self.update()
-          
 if __name__ == "__main__":
     root = Tk()
     app = dicom_anonymizer(root)

--- a/anonymizer_methods.py
+++ b/anonymizer_methods.py
@@ -3,8 +3,6 @@ import sys
 import xml.etree.ElementTree as ET
 import subprocess
 import re
-import glob
-import platform
 import shutil
 from shutil import move
 try:
@@ -14,9 +12,31 @@ except ImportError:
     import dicom
 
 
+###########################################
+# Grep recursively all DICOMs from folder #
+###########################################
+def GrepDicomsFromFolder(dicom_folder):
+
+    # Initialize list of DICOMs and subdirectories
+    dicoms_list  = []
+    subdirs_list = []
+    # Grep DICOM files recursively and insert them in dicoms_list
+    # Same for subdirectories
+    for root, subdirs, files in os.walk(dicom_folder):
+        if len(files) != 0:
+            for dicom_file in files:
+                if dicom_file != ".DS_Store":
+                    dicoms_list.append(os.path.join(root,dicom_file))
+            for subdir in subdirs:
+                subdirs_list.append(subdir)
+        else:
+            sys.exit('Could not find any files in ' + dicom_folder)
+
+    return dicoms_list, subdirs_list
+
 
 ###################################
-# Read dicom fields from XML file #
+# Read DICOM fields from XML file #
 ###################################
 def Grep_DICOM_fields(xml_file):
     xmldoc = ET.parse(xml_file)
@@ -30,20 +50,16 @@ def Grep_DICOM_fields(xml_file):
     return dicom_fields
 
 
-
-
-################################
-# Grep value from dicom fields using PyDicom #
-################################
-def Grep_DICOM_values_PyDicom(dicom_dir, dicom_fields):
+##############################################
+# Grep value from DICOM fields using PyDicom #
+##############################################
+def Grep_DICOM_values_PyDicom(dicom_folder, dicom_fields):
     # Grep first dicom of the directory
     # TO DO: Need to check if file is dicom though, otherwise go to next one
-    file_list = []
-    for f in os.listdir(dicom_dir):
-        file_list.append(f)
-    dicom_file = dicom_dir + os.path.sep + file_list[0]
+    (dicoms_list, subdirs_list) = GrepDicomsFromFolder(dicom_folder)
+    dicom_file    = dicoms_list[0]
     dicom_dataset = dicom.read_file(dicom_file)
-    return_dict={}
+    return_dict   = {}
     # Grep information from dicom header and store them 
     # into dicom_fields dictionary under flag Value
     for field_values in dicom_fields.values():
@@ -57,17 +73,14 @@ def Grep_DICOM_values_PyDicom(dicom_dir, dicom_fields):
     return return_dict
 
 
-
 ################################
-# Grep value from dicom fields #
+# Grep value from DICOM fields #
 ################################
-def Grep_DICOM_values(dicom_dir, dicom_fields):
+def Grep_DICOM_values(dicom_folder, dicom_fields):
     # Grep first dicom of the directory
     # TO DO: Need to check if file is dicom though, otherwise go to next one
-    file_list = []
-    for f in os.listdir(dicom_dir):
-        file_list.append(f)
-    dicom_file = dicom_dir + os.path.sep + file_list[1]
+    (dicoms_list, subdirs_list) = GrepDicomsFromFolder(dicom_folder)
+    dicom_file = dicoms_list[1]
     
     # Grep information from dicom header and store them 
     # into dicom_fields dictionary under flag Value
@@ -81,11 +94,11 @@ def Grep_DICOM_values(dicom_dir, dicom_fields):
     return dicom_fields
 
 
-
 ######################################
 # Run dcmmodify on all fields to zap using PyDicom recursive wrapper#
 ######################################
 def Dicom_zapping_PyDicom(dicom_folder, dicom_fields):
+
     anonymized_folder=dicom_folder+'_anonymized'
     shutil.copytree(dicom_folder, anonymized_folder)
 
@@ -100,7 +113,6 @@ def Dicom_zapping_PyDicom(dicom_folder, dicom_fields):
 # Actual zapping method #
 ######################################
 def actual_zapping(dicom_file, dicom_fields):
-    
 
     dicom_dataset = dicom.read_file(dicom_file)
 
@@ -119,64 +131,82 @@ def actual_zapping(dicom_file, dicom_fields):
 ######################################
 def Dicom_zapping(dicom_folder, dicom_fields):
     
-    # Grep all dicoms present in directory
-    file_list = []
-    for f in os.listdir(dicom_folder):
-        file_list.append(f)
+    # Grep all DICOMs present in directory
+    (dicoms_list, subdirs_list) = GrepDicomsFromFolder(dicom_folder)
 
-    # Create an original_dcm and anonymized_dcm directory in dicom_folder
-    original_dcm = dicom_folder + os.path.sep + "original_dcm"
-    anonymize_dcm = dicom_folder + os.path.sep + "anonymized_dcm"
-    os.mkdir(original_dcm, 0755)
-    os.mkdir(anonymize_dcm, 0755)
-    opSystem = platform.system()
-    # Move all dicom files into anonymized_dcm (we'll move the .bak file into original_dcm once dcmodify has been run) 
-    for f in file_list:
-        move(dicom_folder + os.path.sep + f, anonymize_dcm)
-         
-    # Create the dcmodify command
-    # Have to overcome Mac's Argument list is too long error 
-    # using UNIX xargs which will not work on default Windows config
-    if opSystem == 'Windows':
-        modify_cmd = "dcmodify "
-    else:
-        modify_cmd = "echo "
+    # Create an original_dcm and anonymized_dcm directory in the DICOM folder, as well as subdirectories
+    original_dir  = dicom_folder + os.path.sep + dicom_fields['0010,0010']['Value']
+    anonymize_dir = dicom_folder + os.path.sep + dicom_fields['0010,0010']['Value'] + "_anonymized"
+    os.mkdir(original_dir,  0755)
+    os.mkdir(anonymize_dir, 0755)
+    # Create subdirectories in original and anonymize directory, as found in DICOM folder
+    for subdir in subdirs_list:
+        os.mkdir(original_dir  + os.path.sep + subdir,  0755)
+        os.mkdir(anonymize_dir + os.path.sep + subdir,  0755)
 
+    # Initialize the dcmodify command
+    modify_cmd = "dcmodify "
     changed_fields_nb = 0
     for name in dicom_fields:
         # Grep the new values
         new_val = ""
-        if 'Value' in dicom_fields[name]: 
+        if 'Value' in dicom_fields[name]:
             new_val = dicom_fields[name]['Value']
 
         # Run dcmodify if update is set to True
-        if not dicom_fields[name]['Editable'] and 'Value' in dicom_fields[name]: #kr#
-            modify_cmd += " -ma \"(" + name + ")\"=\" \" " #kr#
-            print modify_cmd
+        if not dicom_fields[name]['Editable'] and 'Value' in dicom_fields[name]:
+            modify_cmd        += " -ma \"(" + name + ")\"=\" \" "
             changed_fields_nb += 1
         else:
             if dicom_fields[name]['Update'] == True:
-                modify_cmd += " -ma \"(" + name + ")\"=\"" + new_val + "\" "
-                print modify_cmd
+                modify_cmd        += " -ma \"(" + name + ")\"=\"" + new_val + "\" "
                 changed_fields_nb += 1
-    modify_cmd += anonymize_dcm + os.path.sep + "*"
-   
-    # If no dicom field was updated
-    if changed_fields_nb > 0:
-        if opSystem == 'Windows': 
-            subprocess.call(modify_cmd, shell=True)
+
+    # Loop through DICOMs and
+    # 1. move DICOM files into anonymized_dir (we'll move the .bak file into original_dcm once dcmodify has been run)
+    # 2. run dcmodify
+    # 3. move .bak file into original directory
+    for dicom in dicoms_list:
+        original_dcm  = dicom.replace(dicom_folder, original_dir)
+        anonymize_dcm = dicom.replace(dicom_folder, anonymize_dir)
+        orig_bak_dcm  = anonymize_dcm + ".bak"
+        if changed_fields_nb > 0:
+            move(dicom, anonymize_dcm)
+            subprocess.call(modify_cmd + anonymize_dcm, shell=True)
+            if os.path.exists(orig_bak_dcm):
+                move(orig_bak_dcm, original_dcm)
         else:
-            subprocess.call(modify_cmd + " |xargs dcmodify", shell=True)
-        globuleux = anonymize_dcm + os.path.sep + "*.bak" 
-        for bak_file in glob.glob(globuleux):
-            first = bak_file.rfind(os.path.sep)
-            last = bak_file.find(".bak")
-            new_name = bak_file[first:last]
-            move(bak_file, original_dcm + new_name)            
+            move(dicom, original_dcm)
+
+    # If anonymize and original folders exist, zip them
+    if os.path.exists(anonymize_dir) and os.path.exists(original_dir):
+        original_zip  = zipDicom(original_dir)
+        anonymize_zip = zipDicom(anonymize_dir)
     else:
-        move(anonymize_dcm + os.path.sep + "*", original_dcm)
-        
-    return anonymize_dcm, original_dcm
+        sys.exit('Failed to anonymize data')
+
+    # If archive anonymized and original DICOMs found, remove subdirectories in root directory
+    if os.path.exists(anonymize_zip) and os.path.exists(original_zip):
+        for subdir in subdirs_list:
+            shutil.rmtree(dicom_folder + os.path.sep + subdir)
+
+    return original_zip, anonymize_zip
+
+
+def zipDicom(directory):
+    archive = directory + '.zip'
+
+    if (os.listdir(directory) == []):
+        sys.exit("The directory " + directory + " is empty and will not be archived.")
+    else:
+        shutil.make_archive(directory, 'zip', directory)
+
+    if (os.path.exists(archive)):
+        shutil.rmtree(directory)
+        return archive
+    else:
+        sys.exit(archive + " could not be created.")
+
 
 ### Test function
 def anonymize_folder(folder_name):

--- a/anonymizer_methods.py
+++ b/anonymizer_methods.py
@@ -7,7 +7,13 @@ import glob
 import platform
 import shutil
 from shutil import move
-import dicom
+try:
+    __import__('pydicom')
+    import pydicom as dicom
+except ImportError:
+    import dicom
+
+
 
 ###################################
 # Read dicom fields from XML file #


### PR DESCRIPTION
This pull request fixes several important bugs:

1. Parses DICOM folder recursively
2. Correct import of pydicom
3. Do not consider .DStore files (inserted by Mac OS)
4. Run dcmodify file by file to fix arguments list too long on Mac OS computers
5. Renamed anonymize and original folder using PatientName information
6. Removed zip button to do it automatically