### PR TITLE
Added Windows executable and scripts used to create it.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,5 @@
+__author__ = 'Karolina Marasinska'
+
+from distutils.core import setup
+import py2exe
+setup(console=['anonymizer_gui.py'])

--- a/win_build.sh
+++ b/win_build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Script to create Windows executable from anonymizer python scripts
+# Make sure the following are installed on your system:
+# - Python.  Get Python from http://www.python.org/download/ and install on your machine.
+# - py2exe. Get py2exe from  http://www.py2exe.org/
+# - pydicom:  python package for working with DICOM files. https://github.com/darcymason/pydicom
+# - DCMtk: http://dicom.offis.de/dcmtk.php.en
+
+echo "This will create a Windows executable from Python scripts!"
+
+# creates windows executable from python files
+python setup.py py2exe
+
+# copy fields_to_zap.xml to same dir (dist/) as exe file
+cp fields_to_zap.xml dist/fields_to_zap.xml


### PR DESCRIPTION
- Added Windows executable in the zip file called Zip_file_with_Windows_Executable.zip.
WARNING: the executable is based on the following pull request: #20

- Also added setup.py and win_build.sh that are necessary to build the Windows executable on Windows.