### PR TITLE
QC fields feature

### DIFF
--- a/dicat/data/fields_to_zap.xml
+++ b/dicat/data/fields_to_zap.xml
@@ -15,6 +15,16 @@
       <editable>no</editable>
     </item>
     <item>
+      <name>0008,0022</name>
+      <description>AcquisitionDate</description>
+      <editable>yes</editable>
+    </item>
+    <item>
+      <name>qc-0008,0022</name>
+      <description>AcquisitionDate</description>
+      <editable>yes</editable>
+    </item>
+    <item>
       <name>0008,0080</name>
       <description>InstitutionName</description>
       <editable>no</editable>

--- a/dicat/data/fields_to_zap.xml
+++ b/dicat/data/fields_to_zap.xml
@@ -15,16 +15,6 @@
       <editable>no</editable>
     </item>
     <item>
-      <name>0008,0022</name>
-      <description>AcquisitionDate</description>
-      <editable>yes</editable>
-    </item>
-    <item>
-      <name>qc-0008,0022</name>
-      <description>AcquisitionDate</description>
-      <editable>yes</editable>
-    </item>
-    <item>
       <name>0008,0080</name>
       <description>InstitutionName</description>
       <editable>no</editable>

--- a/dicat/dicom_anonymizer_frame.py
+++ b/dicat/dicom_anonymizer_frame.py
@@ -17,7 +17,7 @@ Need to load images or external files using these methods, otherwise the
 created application would not find them.
 '''
 import lib.resource_path_methods as PathMethods
-
+from pathlib import Path
 
 
 class dicom_deidentifier_frame_gui(Frame):
@@ -114,7 +114,8 @@ class dicom_deidentifier_frame_gui(Frame):
         self.messageView.grid_forget()
 
         # load XML file and create the field dictionary
-        XML_file   = methods.load_xml("data/fields_to_zap.xml")
+        field_path = Path(__file__).parent.joinpath("data/fields_to_zap.xml")
+        XML_file   = methods.load_xml(field_path)
         field_dict = methods.grep_dicom_fields(XML_file)
 
         # Read DICOM header and grep identifying DICOM field values
@@ -197,7 +198,10 @@ class dicom_deidentifier_frame_gui(Frame):
                     continue
 
                 # set DICOM field names and DICOM values
-                label_text = str(field_dict[keys]['Description']) + ":"
+                if keys.startswith("qc-"):
+                    label_text = f"{field_dict[keys]['Description']} (QC):"
+                else:
+                    label_text = f"{field_dict[keys]['Description']}:"
                 pname_color = "black"
                 if label_text == 'PatientName:':
                     label_text += ' (IDs to label the scan are required)'
@@ -277,28 +281,40 @@ class dicom_deidentifier_frame_gui(Frame):
             methods.update_DICOM_value(self.field_dict, key, new_vals[key_nb])
             key_nb += 1
 
-        if not pname_set:
-            tkmessagebox.showinfo("ERROR", "PatientName DICOM field is required to label the scan")
+        # validate the qc fields
+        try:
+            methods.validate_qc_fields(self.field_dict)
+            qc_fields_valid = True
+        except Exception as e:
+            print(e)
+            tkmessagebox.showinfo("ERROR", e)
             self.deidentify()
-        else:
-            # Edit DICOM field values to de-identify the dataset (deidentified_dcm, original_dcm) = ''
-            (deidentified_dcm, original_dcm) = methods.dicom_zapping(self.dirname, self.field_dict)
-
-            self.field_edit_win.destroy()
-            self.topPanel.destroy()
-
-            if not deidentified_dcm and not original_dcm:
-                # if folder variables are not defined, then permission denied to create the folders
-                self.message.set("PERMISSION DENIED: cannot write in " + self.dirname)
-                self.messageView.configure(fg="dark red", font="Helvetica 16 italic")
-                self.messageView.grid(row=2, column=0, columnspan=2, padx=(0, 10), sticky=E + W)
-            elif os.path.exists(deidentified_dcm) != [] and os.path.exists(original_dcm) != []:
-                # if paths exists, then return success message
-                self.message.set("BOOYA! It's de-identified!")
-                self.messageView.configure(fg="dark green", font= "Helvetica 16 bold italic")
-                self.messageView.grid(row=2, column=0, columnspan=2, padx=(0, 10), sticky=E+W)
+            qc_fields_valid = False
+        
+        # 
+        if qc_fields_valid:
+            if not pname_set:
+                tkmessagebox.showinfo("ERROR", "PatientName DICOM field is required to label the scan")
+                self.deidentify()
             else:
-                # if paths do not exists, then something went wrong
-                self.message.set("An error occured during DICOM files de-identification")
-                self.messageView.configure(fg="dark red", font="Helvetica 16 italic")
-                self.messageView.grid(row=2, column=0, columnspan=2, padx=(0, 10), sticky=E + W)
+                # Edit DICOM field values to de-identify the dataset (deidentified_dcm, original_dcm) = ''
+                (deidentified_dcm, original_dcm) = methods.dicom_zapping(self.dirname, self.field_dict)    
+
+                self.field_edit_win.destroy()
+                self.topPanel.destroy()
+
+                if not deidentified_dcm and not original_dcm:
+                    # if folder variables are not defined, then permission denied to create the folders
+                    self.message.set("PERMISSION DENIED: cannot write in " + self.dirname)
+                    self.messageView.configure(fg="dark red", font="Helvetica 16 italic")
+                    self.messageView.grid(row=2, column=0, columnspan=2, padx=(0, 10), sticky=E + W)
+                elif os.path.exists(deidentified_dcm) != [] and os.path.exists(original_dcm) != []:
+                    # if paths exists, then return success message
+                    self.message.set("BOOYA! It's de-identified!")
+                    self.messageView.configure(fg="dark green", font= "Helvetica 16 bold italic")
+                    self.messageView.grid(row=2, column=0, columnspan=2, padx=(0, 10), sticky=E+W)
+                else:
+                    # if paths do not exists, then something went wrong
+                    self.message.set("An error occured during DICOM files de-identification")
+                    self.messageView.configure(fg="dark red", font="Helvetica 16 italic")
+                    self.messageView.grid(row=2, column=0, columnspan=2, padx=(0, 10), sticky=E + W)

--- a/dicat/lib/dicom_anonymizer_methods.py
+++ b/dicat/lib/dicom_anonymizer_methods.py
@@ -208,7 +208,7 @@ def dicom_zapping(dicom_folder, dicom_fields):
       original_zip  -> path to the zip file of the original DICOMs
      :rtype: str
 
-    """   
+    """
 
     # Grep all DICOMs present in directory
     (dicoms_list, subdirs_list) = grep_dicoms_from_folder(dicom_folder)

--- a/dicat/lib/dicom_anonymizer_methods.py
+++ b/dicat/lib/dicom_anonymizer_methods.py
@@ -180,9 +180,13 @@ def read_dicom_with_pydicom(dicom_file, dicom_fields):
     # into dicom_fields dictionary under flag Value
     # Dictionnary of DICOM values to be returned
     for name in dicom_fields:
+        # choose the original name even if the name is starting with "qc-"
+        qname = name[3:] if name.startswith("qc-") else name
+
         try:
-            description = dicom_fields[name]['Description']
+            description = dicom_fields[qname]['Description']
             value = dicom_dataset.data_element(description).value
+            # change the original name (qc or not qc)
             dicom_fields[name]['Value'] = value
         except:
             continue
@@ -204,7 +208,7 @@ def dicom_zapping(dicom_folder, dicom_fields):
       original_zip  -> path to the zip file of the original DICOMs
      :rtype: str
 
-    """
+    """   
 
     # Grep all DICOMs present in directory
     (dicoms_list, subdirs_list) = grep_dicoms_from_folder(dicom_folder)
@@ -242,6 +246,34 @@ def dicom_zapping(dicom_folder, dicom_fields):
 
     # return zip files
     return deidentified_zip, original_zip
+
+def validate_qc_fields(dicom_fields):
+    """
+    Validate the QC fields are identical to their non-qc counterpart.
+
+    :param dicom_fields: Dictionary with DICOM fields & values to use
+     :type dicom_fields: dict
+
+    :return: None
+    """
+
+    for tag in dicom_fields:
+
+        # qc field?
+        if not dicom_fields[tag]['DICOM_tag'].startswith('qc-'):
+            continue
+        # if value not changed
+        if 'Value' not in dicom_fields[tag]:
+            continue
+
+        # get new value
+        original_tag = tag[3:]
+        qc_val = str(dicom_fields[tag]['Value']).strip()
+        non_qc_val = str(dicom_fields[original_tag]['Value']).strip()
+
+        # validate associated (field <> qc field)
+        if qc_val != non_qc_val:
+            raise Exception("'(" + original_tag + ") " + dicom_fields[original_tag]['Description'] + "' and QC Values are different!")
 
 
 def pydicom_zapping(dicom_file, dicom_fields):

--- a/dicat/welcome_frame.py
+++ b/dicat/welcome_frame.py
@@ -9,6 +9,7 @@ Need to load images or external files using these methods, otherwise the
 created application would not find them.
 '''
 import lib.resource_path_methods as PathMethods
+from pathlib import Path
 
 class welcome_frame_gui(Frame):
 
@@ -20,9 +21,9 @@ class welcome_frame_gui(Frame):
         self.frame = Frame(self.parent)
         self.frame.pack(expand=1, fill='both')
 
-
         # Insert DICAT logo on the right side of the screen
-        load_img = PathMethods.resource_path("images/DICAT_logo.gif")
+        imgp = Path(__file__).parent.joinpath("images/DICAT_logo.gif")
+        load_img = PathMethods.resource_path(imgp)
         imgPath  = load_img.return_path()
         logo     = PhotoImage(file = imgPath)
         logo_image = Label(self.frame,


### PR DESCRIPTION
This PR adds a new feature:
- [x] QC fields feature: allow a field to be duplicated in the `field_to_zap.xml` file for a QC on the GUI. QC fields are not integrated in the final file. QC fields must begin with a `qc-` prefix in their `name` tag in the `field_to_zap.xml` file. E.g. 

```xml
<!-- not qc field -->
<item>
  <name>0008,0022</name>
  <description>AcquisitionDate</description>
  <editable>yes</editable>
</item>

<!-- qc field, associated with the above one -->
<item>
  <name>qc-0008,0022</name>
  <description>AcquisitionDate</description>
  <editable>yes</editable>
</item>
```

- [x] also, fixes small issues on path linking. 