### PR TITLE
Re-insert deleted fields feature

### DIFF
--- a/dicat/data/fields_to_zap.xml
+++ b/dicat/data/fields_to_zap.xml
@@ -15,12 +15,6 @@
       <editable>no</editable>
     </item>
     <item>
-      <name>0008,0022</name>
-      <description>AcquisitionDate</description>
-      <editable>yes</editable>
-      <forceInsert>yes</forceInsert>
-    </item>
-    <item>
       <name>0008,0080</name>
       <description>InstitutionName</description>
       <editable>no</editable>

--- a/dicat/data/fields_to_zap.xml
+++ b/dicat/data/fields_to_zap.xml
@@ -15,6 +15,12 @@
       <editable>no</editable>
     </item>
     <item>
+      <name>0008,0022</name>
+      <description>AcquisitionDate</description>
+      <editable>yes</editable>
+      <forceInsert>yes</forceInsert>
+    </item>
+    <item>
       <name>0008,0080</name>
       <description>InstitutionName</description>
       <editable>no</editable>

--- a/dicat/dicom_anonymizer_frame.py
+++ b/dicat/dicom_anonymizer_frame.py
@@ -268,6 +268,20 @@ class dicom_deidentifier_frame_gui(Frame):
         # Remove the first item (corresponding to the title row in the displayed table)
         new_vals.pop(0)
 
+        print(self.edited_entries)
+        print(new_vals)
+
+
+        print(self.field_dict['0008,0022'])
+
+        # force insert fields
+        self.field_dict = methods.force_insert_fields(self.field_dict)
+
+        print(self.field_dict['0008,0022'])
+
+        raise
+
+        # update dicom values
         key_nb = 0
         pname_set = 0
         for key in self.field_dict.keys():

--- a/dicat/dicom_anonymizer_frame.py
+++ b/dicat/dicom_anonymizer_frame.py
@@ -185,6 +185,10 @@ class dicom_deidentifier_frame_gui(Frame):
             self.key_index = 1
             for keys in fields_keys:
 
+                # set force insert field before editable fields
+                if 'ForceInsert' in field_dict[keys] and field_dict[keys]['ForceInsert']:
+                    self.edited_entries[self.key_index].set("")
+
                 # set the Editable of the dictionary to True for all entries now
                 # that they are all editable in the GUI. Note, the reason we don't
                 # modify the XML here is so that the mass_deidentifier can still
@@ -268,19 +272,6 @@ class dicom_deidentifier_frame_gui(Frame):
         # Remove the first item (corresponding to the title row in the displayed table)
         new_vals.pop(0)
 
-        print(self.edited_entries)
-        print(new_vals)
-
-
-        print(self.field_dict['0008,0022'])
-
-        # force insert fields
-        self.field_dict = methods.force_insert_fields(self.field_dict)
-
-        print(self.field_dict['0008,0022'])
-
-        raise
-
         # update dicom values
         key_nb = 0
         pname_set = 0
@@ -308,7 +299,7 @@ class dicom_deidentifier_frame_gui(Frame):
                 self.messageView.grid(row=2, column=0, columnspan=2, padx=(0, 10), sticky=E + W)
             elif os.path.exists(deidentified_dcm) != [] and os.path.exists(original_dcm) != []:
                 # if paths exists, then return success message
-                self.message.set("BOOYA! It's de-identified!")
+                self.message.set("It's de-identified!")
                 self.messageView.configure(fg="dark green", font= "Helvetica 16 bold italic")
                 self.messageView.grid(row=2, column=0, columnspan=2, padx=(0, 10), sticky=E+W)
             else:

--- a/dicat/lib/dicom_anonymizer_methods.py
+++ b/dicat/lib/dicom_anonymizer_methods.py
@@ -264,44 +264,29 @@ def pydicom_zapping(dicom_file, dicom_fields):
 
     # tags to force insert in the final file
     forceInsertTags = [tag for tag in dicom_fields 
-                       if 'ForceInsert' in dicom_fields[tag]
-                       and dicom_fields[tag]['ForceInsert']]
+                       if dicom_fields[tag].get('ForceInsert', False)]
 
     for name in dicom_fields:
         new_val = ""
         if 'Value' in dicom_fields[name]:
             new_val = str(dicom_fields[name]['Value']).strip()
 
-        if dicom_fields[name]['Editable'] is True:
-            try:
-                dicom_dataset.data_element(
-                    dicom_fields[name]['Description']).value = new_val
-            except KeyError as ke:
-                # key error are triggered when a key is not found in the DICOM 
-                # file header. If 'forceInsert' is true for this field, it will
-                # be forcefully added here.
-                # 
-                # if force insert tag, check the value change
-                if name in forceInsertTags:
-                    setattr(dicom_dataset, dicom_fields[name]['Description'], new_val)
-                continue
-            except:
-                continue
-        else:
-            try:
-                dicom_dataset.data_element(
-                    dicom_fields[name]['Description']).value = ''
-            except KeyError as ke:
-                # key error are triggered when a key is not found in the DICOM 
-                # file header. If 'forceInsert' is true for this field, it will
-                # be forcefully added here.
-                # 
-                # if force insert tag, check the value change
-                if name in forceInsertTags:
-                    setattr(dicom_dataset, dicom_fields[name]['Description'], '')
-                continue
-            except:
-                continue
+        # value to insert
+        val = new_val if dicom_fields[name]['Editable'] else ''
+
+        try:
+            dicom_dataset.data_element(
+                dicom_fields[name]['Description']).value = val
+        except KeyError as ke:
+            # key error are triggered when a key is not found in the DICOM
+            # file header. If 'forceInsert' is true for this field, it will
+            # be forcefully added here.
+            #
+            # if force insert tag, check the value change
+            if name in forceInsertTags:
+                setattr(dicom_dataset, dicom_fields[name]['Description'], val)
+        except:
+            continue
     dicom_dataset.save_as(dicom_file)
 
 

--- a/dicat/lib/dicom_anonymizer_methods.py
+++ b/dicat/lib/dicom_anonymizer_methods.py
@@ -183,13 +183,9 @@ def read_dicom_with_pydicom(dicom_file, dicom_fields):
     # into dicom_fields dictionary under flag Value
     # Dictionnary of DICOM values to be returned
     for name in dicom_fields:
-        # choose the original name even if the name is starting with "qc-"
-        qname = name[3:] if name.startswith("qc-") else name
-
         try:
-            description = dicom_fields[qname]['Description']
+            description = dicom_fields[name]['Description']
             value = dicom_dataset.data_element(description).value
-            # change the original name (qc or not qc)
             dicom_fields[name]['Value'] = value
         except:
             continue


### PR DESCRIPTION
This PR adds a new feature to re-insert deleted fields, or fields not found in DICOM files.

It works by adding a new bool tag in the `fields_to_zap.xml` config file, named `forceInsert`.

```xml
<item>
      <name>0008,0022</name>
      <description>AcquisitionDate</description>
      <editable>yes</editable>
      <forceInsert>yes</forceInsert>
</item>
```

If fields are not found in the DICOM file but the `forceInsert` is `yes`, this field will be added in the final de-identified file.