### PR TITLE
DICOM De-Identifier - Zap OrginalAttributesSequence

### DIFF
--- a/dicat/data/fields_to_zap.xml
+++ b/dicat/data/fields_to_zap.xml
@@ -820,6 +820,11 @@
         <editable>no</editable>
     </item>
     <item>
+        <name>0400,0561</name>
+        <description>OriginalAttributesSequence</description>
+        <editable>no</editable>
+    </item>
+    <item>
         <name>2200,0005</name>
         <description>BarcodeValue</description>
         <editable>no</editable>

--- a/dicat/data/fields_to_zap_for_open_science.xml
+++ b/dicat/data/fields_to_zap_for_open_science.xml
@@ -1291,6 +1291,11 @@
         <editable>no</editable>
     </item>
     <item>
+        <name>0400,0561</name>
+        <description>OriginalAttributesSequence</description>
+        <editable>no</editable>
+    </item>
+    <item>
         <name>2100,0040</name>
         <description>CreationDate</description>
         <editable>no</editable>


### PR DESCRIPTION
While working on some DICOMs, I found that the attribute `(0400,0561) / OriginalAttributesSequence` contains a history of previously modified attributes, along with their values, and can thus contain identifying information. Therefore, I added this attribute to the lists of attributes to zap.

I did not add the attributes nested in `OriginalAttributesSequence` but I can do so if wanted. In general, I never used DICAT so please tell me if I may have missed something.